### PR TITLE
Made fastq-dump work properly for paired reads

### DIFF
--- a/scripts/GenFSGopher.pl
+++ b/scripts/GenFSGopher.pl
@@ -190,7 +190,11 @@ sub tsvToMakeHash{
         $$make{$filename1}={
           CMD=>[
             "\@echo Downloading $make_target $F{srarun_acc}",
-            "fastq-dump --defline-seq '$seqIdTemplate' --defline-qual '+' --split-files -O $dumpdir --gzip $F{srarun_acc} ",
+            "fastq-dump --defline-seq '$seqIdTemplate' --defline-qual '+' --split-3 -O $dumpdir $F{srarun_acc}",
+            "if [ ! -f $dumpdir/$F{srarun_acc}_1.fastq ]; then mv $dumpdir/$F{srarun_acc}.fastq $dumpdir/$F{srarun_acc}_1.fastq; \
+            elif [ -f $dumpdir/$F{srarun_acc}_1.fastq -a -f $dumpdir/$F{srarun_acc}_2.fastq ]; then rm -f $dumpdir/$F{srarun_acc}.fastq; fi",
+            "gzip -f $dumpdir/$F{srarun_acc}_1.fastq",
+            "gzip -f $dumpdir/$F{srarun_acc}_2.fastq || true",
             "mv $dumpdir/$F{srarun_acc}_1.fastq.gz '$make_target'",
           ],
           DEP=>[
@@ -198,6 +202,7 @@ sub tsvToMakeHash{
             "prefetch.done",
           ],
         };
+
         push(@{ $$make{"all"}{DEP} }, $filename1, $filename2);
 
         $$make{"prefetch.done"}{CMD}[0] .= " $F{srarun_acc}";


### PR DESCRIPTION
Changed fastq-dump --split-files to --split-3 and added logic to handle the files which --split-3 produces, also removed the use of --gzip since it is deprecated and can lead to corrupted gz files, it does chuck out unpaired reads so if you wish to add some handling for that it could be a good idea.

Much slower unfortunately but that's the price for it actually working...