### PR TITLE
added install & usage for conda/docker/singularity

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,50 @@ Technical Outreach and Assistance for States Team (TOAST) developed benchmark da
 | 5 | Non-VOI/VOC lineages | A cohort of 39 samples from representative non VOI/VOC lineages as of 05/30/2021, Illumina platform, amplicon-based approach | To benchmark lineage-calling pipeline nonspecific to VOI/VOCs, bioinformatics pipeline validation  |
 | 6 | Failed QC | A cohort of 24 samples failed basic QC metrics, covering 8 possible failure scenarios, Illumina platform, amplicon-based approach  | To serve as controls to test bioinformatics quality control cutoffs |
 
-## Installation
+## Installation & Usage
+
+An NCBI API key is required to use this tool. [See here for information on how to obtain your own NCBI API key](https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities/)
+
+### Conda 
+*datasets-sars-cov-2* is available on [BioConda](https://bioconda.github.io/recipes/uscdc-datasets-sars-cov-2/README.html)
+```bash
+conda create -n datasets-sars-cov-2 -c conda-forge -c bioconda uscdc-datasets-sars-cov-2
+
+conda activate datasets-sars-cov-2
+
+export NCBI_API_KEY="<your-NCBI-API-key-here>"
+
+# the path to the input TSV may differ depending on how & where you installed conda; below is default location for miniconda3 installed on linux
+GenFSGopher.pl --numcpus 8 --compressed --outdir vocvoi-dataset ~/miniconda3/envs/datasets-sars-cov-2/share/uscdc-datasets-sars-cov-2/sars-cov-2-voivoc.tsv
+```
+
+### Docker
+The [StaPH-B working group](https://staphb.org/) maintains a [docker image](https://hub.docker.com/r/staphb/datasets-sars-cov-2) for *datasets-sars-cov-2*. The dockerfile can be found [here](https://github.com/StaPH-B/docker-builds/tree/master/datasets-sars-cov-2/).
+
+The input TSVs are located here within the StaPH-B docker image: `/home/user/datasets-sars-cov-2/datasets/`
+
+There is also a [BioContainer docker image](https://quay.io/repository/biocontainers/uscdc-datasets-sars-cov-2?tab=tags) which contains the (bio)conda environment for this repository. The example below uses the StaPH-B docker image, but similar commands can be used with the BioContainer docker image. The input TSVs are located here within the BioContainer docker image: `/usr/local/share/uscdc-datasets-sars-cov-2/`
+```bash
+docker pull staphb/datasets-sars-cov-2:latest
+
+# broken into 2 lines for readability
+docker run --rm -v $PWD:/data -u $(id -u):$(id -g) staphb/datasets-sars-cov-2:latest /bin/bash -c \
+'export NCBI_API_KEY="<your-NCBI-API-key-here>"; GenFSGopher.pl --numcpus 8 --compressed --outdir /data/vocvoi-dataset /home/user/datasets-sars-cov-2/datasets/sars-cov-2-voivoc.tsv''
+```
+
+### Singularity
+The StaPH-B docker image can be converted to singularity image format and utilitzed in a similar manner.
+```bash
+singularity build staphb.datasets-sars-cov-3.sif docker://staphb/datasets-sars-cov-2:latest
+
+# broken into 3 lines for readabilty
+singularity exec -B $PWD:/data --no-home staphb.datasets-sars-cov-3.sif /bin/bash -c \
+"export HOME=/home/user; export NCBI_API_KEY="<your-NCBI-API-key-here>"; \
+GenFSGopher.pl --numcpus 8 --compressed --outdir /data/vocvoi-dataset /home/user/datasets-sars-cov-2/datasets/sars-cov-2-voivoc.tsv"
+```
+
+
+### From Source Code
 
 Grab the latest stable release under the releases tab.  If you are feeling adventurous, use `git clone`!  Include the scripts directory in your path.  For example, if you downloaded this project into your local bin directory:
 
@@ -31,7 +74,7 @@ After obtaining an NCBI API key, add it to your environment with
 
 where `unique_api_key_goes_here` is a unique hexadecimal number with characters from 0-9 and a-f.
 
-### Dependencies
+#### Dependencies
 
 In addition to the installation above, please install the following.
 
@@ -42,7 +85,7 @@ In addition to the installation above, please install the following.
 5. wget - Brew users: `brew install wget`
 6. sha256sum - Linux-based OSs should have this already; Other users should see the relevant installation section below.
 
-### Installing edirect
+#### Installing edirect
 
   Modified instructions from https://www.ncbi.nlm.nih.gov/books/NBK179288/
 
@@ -60,7 +103,7 @@ In addition to the installation above, please install the following.
 **NOTE**: edirect needs an NCBI API key.
 Instructions can be found at https://ncbiinsights.ncbi.nlm.nih.gov/2017/11/02/new-api-keys-for-the-e-utilities
 
-### Installing sha256sum
+#### Installing sha256sum
 
 If you do not have sha256sum (e.g., if you are on MacOS), then try to make the shell function and export it.
 
@@ -127,8 +170,6 @@ To create your own dataset and to make it compatible with the existing script(s)
 If this project has helped you, please cite both this website and the original publication:
 
 Timme, Ruth E., et al. "Benchmark datasets for phylogenomic pipeline validation, applications for foodborne pathogen surveillance." PeerJ 5 (2017): e3893.
-
-[![Build Status](https://travis-ci.org/globalmicrobialidentifier-WG3/datasets.svg?branch=master)](https://travis-ci.org/globalmicrobialidentifier-WG3/datasets)
 
 ---
 ## Notices and Disclaimers


### PR DESCRIPTION
This PR adds install & usage instructions for conda, docker, and singularity. I also altered the formatting of some headings for readability. You can view the rendered markdown on my fork: https://github.com/kapsakcj/datasets-sars-cov-2

To test, I used the following versions though relatively recent versions of all should work properly. Except maybe Singularity 2.x.x, don't even bother trying - it's not worth it.
  * conda 4.11.0 (installed via miniconda3)
  * docker 20.10.12, build e91ed57
  * singularity 3.8.0

Singularity was the oddball, as per usual, since it auto-mounts your home drive `/home/curtis_kapsak` and sets it it as $HOME by default. You have to trick the container into thinking `$HOME=/home/user` due to the [vdb-config/sra-toolkit workaround that Kelsey implemented in the StaPH-B docker image](https://github.com/StaPH-B/docker-builds/blob/24a3b669759e5d89d30c2ef921ce2d555981665c/datasets-sars-cov-2/0.6.2/Dockerfile#L68). It won't run without it.

I tested out the StaPH-B container just now and previously, if you'd like to see [some of the output of `GenFSGopher.pl`](https://github.com/StaPH-B/docker-builds/pull/264#issuecomment-1024749787). Fastq files downloaded properly & checksums looked good. I've successfully downloaded all 6 datasets using the Staph-B docker image.

Also removed the TravisCI badge since Travis-ci.org is dead & it pointed to a different repo anyways (globalmicrobialidentifier-WG3/datasets)

Please feel free to test and/or suggest changes to this PR.

Big thank you to @rpetit3 for adding this to bioconda and @k-florek for creating the StaPH-B docker image! This wouldn't be possible without them 👏 